### PR TITLE
Tabs not hiding their labels if they already fit the screen nicely + bugfixes

### DIFF
--- a/SmoothTab/Classes/SmoothTabDefaultOptions.swift
+++ b/SmoothTab/Classes/SmoothTabDefaultOptions.swift
@@ -18,6 +18,7 @@ public struct SmoothTabDefaultOptions {
 	/// Selected View Options
     static let titleFont: UIFont = .systemFont(ofSize: 14)
     static let titleColor: UIColor = .black
+    static let deselectedTitleColor: UIColor = .gray
 	static let cornerRadius: CornerRadius = .rounded
 	static let borderWidth: CGFloat = 0.0
 	static let borderColor: UIColor = .black

--- a/SmoothTab/Classes/SmoothTabItem.swift
+++ b/SmoothTab/Classes/SmoothTabItem.swift
@@ -28,6 +28,14 @@ public struct SmoothTabItem {
         self.tintColor = tintColor
         self.tag = (tag != "") ? tag : title
     }
+    
+    public func expectedWidth(for font: UIFont) -> CGFloat {
+        return self.title.boundingRect(
+            with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [NSAttributedString.Key.font: font],
+            context: nil).width + self.image.size.width
+    }
 }
 
 extension SmoothTabItem: Equatable { }

--- a/SmoothTab/Classes/SmoothTabItem.swift
+++ b/SmoothTab/Classes/SmoothTabItem.swift
@@ -13,16 +13,19 @@ public struct SmoothTabItem {
     public let selectedImage: UIImage
     public let title: String
     public let tintColor: UIColor
+    public let tag: String
 
     public init (
         title: String,
         image: UIImage,
         selectedImage: UIImage? = nil,
-        tintColor: UIColor
+        tintColor: UIColor,
+        tag: String = ""
         ) {
         self.title = title
         self.image = image
         self.selectedImage = selectedImage ?? image
         self.tintColor = tintColor
+        self.tag = (tag != "") ? tag : title
     }
 }

--- a/SmoothTab/Classes/SmoothTabItem.swift
+++ b/SmoothTab/Classes/SmoothTabItem.swift
@@ -29,3 +29,8 @@ public struct SmoothTabItem {
         self.tag = (tag != "") ? tag : title
     }
 }
+
+extension SmoothTabItem: Equatable { }
+public func == (lhs: SmoothTabItem, rhs: SmoothTabItem) -> Bool {
+    return (lhs.tag == rhs.tag && lhs.title == rhs.title)
+}

--- a/SmoothTab/Classes/SmoothTabItem.swift
+++ b/SmoothTab/Classes/SmoothTabItem.swift
@@ -32,5 +32,5 @@ public struct SmoothTabItem {
 
 extension SmoothTabItem: Equatable { }
 public func == (lhs: SmoothTabItem, rhs: SmoothTabItem) -> Bool {
-    return (lhs.tag == rhs.tag && lhs.title == rhs.title)
+    return (lhs.tag == rhs.tag && lhs.title == rhs.title && lhs.image == rhs.image && lhs.selectedImage == rhs.selectedImage)
 }

--- a/SmoothTab/Classes/SmoothTabOptions.swift
+++ b/SmoothTab/Classes/SmoothTabOptions.swift
@@ -35,6 +35,7 @@ public struct SmoothTabOptions {
 	/// Selected View Options
 	public var titleFont: UIFont = SmoothTabDefaultOptions.titleFont
 	public var titleColor: UIColor = SmoothTabDefaultOptions.titleColor
+    public var deselectedTitleColor: UIColor = SmoothTabDefaultOptions.deselectedTitleColor
 	public var cornerRadius: CornerRadius = SmoothTabDefaultOptions.cornerRadius
 	public var borderWidth: CGFloat = SmoothTabDefaultOptions.borderWidth
 	public var borderColor: UIColor = SmoothTabDefaultOptions.borderColor

--- a/SmoothTab/Classes/SmoothTabView.swift
+++ b/SmoothTab/Classes/SmoothTabView.swift
@@ -46,7 +46,7 @@ public class SmoothTabView: UIView {
         didSet {
             selectItem(at: selectedSegmentIndex)
             selectedView.alpha = 1
-            transition(from: oldValue, to: selectedSegmentIndex)
+            transition(from: oldValue, to: selectedSegmentIndex, animated: selectedSegmentIndex != oldValue)
             delegate?.smootItemSelected(at: selectedSegmentIndex)
         }
     }
@@ -329,22 +329,26 @@ private extension SmoothTabView {
 
 /// Animating
 private extension SmoothTabView {
-    func transition(from fromIndex: Int, to toIndex: Int) {
-        let animation = {
+    func transition(from fromIndex: Int, to toIndex: Int, animated: Bool = true) {
+        let actions = {
             self.stackView.layoutIfNeeded()
             self.layoutIfNeeded()
             self.moveHighlighterView(toItemAt: toIndex)
         }
-
-        UIView.animate(
-            withDuration: SwitchAnimationDuration,
-            delay: 0,
-            usingSpringWithDamping: 0.7,
-            initialSpringVelocity: 3,
-            options: [],
-            animations: animation,
-            completion: nil
-        )
+        
+        if animated {
+            UIView.animate(
+                withDuration: SwitchAnimationDuration,
+                delay: 0,
+                usingSpringWithDamping: 0.7,
+                initialSpringVelocity: 3,
+                options: [],
+                animations: actions,
+                completion: nil
+            )
+        } else {
+            actions()
+        }
     }
 
     func moveHighlighterView(toItemAt toIndex: Int) {

--- a/SmoothTab/Classes/SmoothTabView.swift
+++ b/SmoothTab/Classes/SmoothTabView.swift
@@ -44,10 +44,11 @@ public class SmoothTabView: UIView {
 
     private var selectedSegmentIndex: Int = 0 {
         didSet {
-            selectItem(at: selectedSegmentIndex)
-            selectedView.alpha = 1
-            transition(from: oldValue, to: selectedSegmentIndex, animated: selectedSegmentIndex != oldValue)
-            delegate?.smootItemSelected(at: selectedSegmentIndex)
+            if selectItem(at: selectedSegmentIndex) == true {
+                selectedView.alpha = 1
+                transition(from: oldValue, to: selectedSegmentIndex, animated: selectedSegmentIndex != oldValue)
+                delegate?.smootItemSelected(at: selectedSegmentIndex)
+            }
         }
     }
 
@@ -110,7 +111,9 @@ public class SmoothTabView: UIView {
         itemsViews.forEach { stackView.addArrangedSubview($0) }
     }
 
-    private func selectItem(at index: Int) {
+    @discardableResult
+    private func selectItem(at index: Int) -> Bool {
+        guard itemsViews.count > index else { return false }
         let selectedView = itemsViews[index]
         itemsViews
             .enumerated()
@@ -129,6 +132,7 @@ public class SmoothTabView: UIView {
         if let label = selectedView.arrangedSubviews.last as? UILabel {
             label.isHidden = false
         }
+        return true
     }
 
     override public func didMoveToWindow() {

--- a/SmoothTab/Classes/SmoothTabView.swift
+++ b/SmoothTab/Classes/SmoothTabView.swift
@@ -42,14 +42,13 @@ public class SmoothTabView: UIView {
 
     private var options: SmoothTabOptions = .default
 
-    private var selectedSegmentIndex: Int? = nil {
+    private var selectedSegmentIndex: Int = 0 {
         didSet {
-            guard let recentlySelectedIndex = selectedSegmentIndex else { return }
-            if recentlySelectedIndex != oldValue {
-                selectItem(at: recentlySelectedIndex)
+            if oldValue != selectedSegmentIndex {
+                selectItem(at: selectedSegmentIndex)
                 selectedView.alpha = 1
-                transition(from: oldValue ?? 0, to: recentlySelectedIndex)
-                delegate?.smootItemSelected(at: recentlySelectedIndex)
+                transition(from: oldValue, to: selectedSegmentIndex)
+                delegate?.smootItemSelected(at: selectedSegmentIndex)
             }
         }
     }
@@ -136,7 +135,7 @@ public class SmoothTabView: UIView {
 
     override public func didMoveToWindow() {
         super.didMoveToWindow()
-		guard window != nil, let selectedSegmentIndex = selectedSegmentIndex else { return }
+		guard window != nil else { return }
 		layoutIfNeeded()
 		if itemsViews.count > selectedSegmentIndex {
 			transition(from: selectedSegmentIndex, to: selectedSegmentIndex)
@@ -145,9 +144,7 @@ public class SmoothTabView: UIView {
 
     override public func layoutSubviews() {
         super.layoutSubviews()
-        if let indexToHighlight = selectedSegmentIndex {
-            moveHighlighterView(toItemAt: indexToHighlight)
-        }
+        moveHighlighterView(toItemAt: selectedSegmentIndex)
     }
 
     public func tapItem(at index: Int) {

--- a/SmoothTab/Classes/SmoothTabView.swift
+++ b/SmoothTab/Classes/SmoothTabView.swift
@@ -42,13 +42,14 @@ public class SmoothTabView: UIView {
 
     private var options: SmoothTabOptions = .default
 
-    private var selectedSegmentIndex: Int = 0 {
+    private var selectedSegmentIndex: Int? = nil {
         didSet {
-            if oldValue != selectedSegmentIndex {
-                selectItem(at: selectedSegmentIndex)
+            guard let recentlySelectedIndex = selectedSegmentIndex else { return }
+            if recentlySelectedIndex != oldValue {
+                selectItem(at: recentlySelectedIndex)
                 selectedView.alpha = 1
-                transition(from: oldValue, to: selectedSegmentIndex)
-                delegate?.smootItemSelected(at: selectedSegmentIndex)
+                transition(from: oldValue ?? 0, to: recentlySelectedIndex)
+                delegate?.smootItemSelected(at: recentlySelectedIndex)
             }
         }
     }
@@ -135,7 +136,7 @@ public class SmoothTabView: UIView {
 
     override public func didMoveToWindow() {
         super.didMoveToWindow()
-		guard window != nil else { return }
+		guard window != nil, let selectedSegmentIndex = selectedSegmentIndex else { return }
 		layoutIfNeeded()
 		if itemsViews.count > selectedSegmentIndex {
 			transition(from: selectedSegmentIndex, to: selectedSegmentIndex)
@@ -144,7 +145,9 @@ public class SmoothTabView: UIView {
 
     override public func layoutSubviews() {
         super.layoutSubviews()
-        moveHighlighterView(toItemAt: selectedSegmentIndex)
+        if let indexToHighlight = selectedSegmentIndex {
+            moveHighlighterView(toItemAt: indexToHighlight)
+        }
     }
 
     public func tapItem(at index: Int) {

--- a/SmoothTab/Classes/SmoothTabView.swift
+++ b/SmoothTab/Classes/SmoothTabView.swift
@@ -44,12 +44,10 @@ public class SmoothTabView: UIView {
 
     private var selectedSegmentIndex: Int = 0 {
         didSet {
-            if oldValue != selectedSegmentIndex {
-                selectItem(at: selectedSegmentIndex)
-                selectedView.alpha = 1
-                transition(from: oldValue, to: selectedSegmentIndex)
-                delegate?.smootItemSelected(at: selectedSegmentIndex)
-            }
+            selectItem(at: selectedSegmentIndex)
+            selectedView.alpha = 1
+            transition(from: oldValue, to: selectedSegmentIndex)
+            delegate?.smootItemSelected(at: selectedSegmentIndex)
         }
     }
 


### PR DESCRIPTION
In short the changes are:
1. If there are very few tabs of labels are small/short enough and all can fit the screen, the tabs won't hide their labels. This looks better.
There is a new parameter called `deselectedTitleColor` in options now to set a color for labels in unselected tabs (defaults to grey).

<img width="830" alt="screenshot 2019-01-22 18 29 16" src="https://user-images.githubusercontent.com/5410835/51549766-b2b83600-1e73-11e9-9b54-5fa9a271b53f.png">

2. issue #3 fixed
3. added tag to `SmoothTabItem` and made these items equatable. This makes it possible to rely directly on the array of tab items later, when you do something (like manage view controllers) based on their presence/absence. In my case I had tabs, which could dynamically appear as data appears and the number of tabs would change thus changing the presence of view controllers in tied UIPageViewController, also tab titles could change and could not be relied upon.

Please see also commit messages for descriptions of individual changes made.